### PR TITLE
Merge back evgeny-goldin/spock-extensions version of TempDirectory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,13 +2,12 @@ apply plugin: "groovy"
 apply plugin: "maven"
 
 repositories {
-	mavenRepo urls: "http://m2repo.spockframework.org/snapshots/"
 	mavenCentral()
 }
 
 dependencies {
-	groovy "org.codehaus.groovy:groovy:1.7.5"
-	compile "org.spockframework:spock-core:0.5-groovy-1.7-SNAPSHOT"
+	groovy "org.codehaus.groovy:groovy:2.0.8"
+	compile "org.spockframework:spock-core:0.7-groovy-2.0"
 }
 
 version = "1.0-SNAPSHOT"

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-	groovy "org.codehaus.groovy:groovy:2.0.8"
-	compile "org.spockframework:spock-core:0.7-groovy-2.0"
+	groovy "org.codehaus.groovy:groovy:1.8.8"
+	compile "org.spockframework:spock-core:0.7-groovy-1.8"
 }
 
 version = "1.0-SNAPSHOT"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name='spock-extensions'

--- a/src/main/groovy/com/energizedwork/spock/extensions/TempDirectory.groovy
+++ b/src/main/groovy/com/energizedwork/spock/extensions/TempDirectory.groovy
@@ -1,9 +1,17 @@
 package com.energizedwork.spock.extensions
 
 import org.spockframework.runtime.extension.ExtensionAnnotation
-import java.lang.annotation.*
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 @ExtensionAnnotation(TempDirectoryExtension)
-@interface TempDirectory {}
+@interface TempDirectory {
+    String baseDir() default 'build/test'
+
+    boolean clean() default true
+}

--- a/src/main/groovy/com/energizedwork/spock/extensions/TempDirectory.groovy
+++ b/src/main/groovy/com/energizedwork/spock/extensions/TempDirectory.groovy
@@ -12,6 +12,5 @@ import java.lang.annotation.Target
 @ExtensionAnnotation(TempDirectoryExtension)
 @interface TempDirectory {
     String baseDir() default 'build/test'
-
-    boolean clean() default true
+    boolean clean() default false
 }

--- a/src/main/groovy/com/energizedwork/spock/extensions/TempDirectoryExtension.groovy
+++ b/src/main/groovy/com/energizedwork/spock/extensions/TempDirectoryExtension.groovy
@@ -45,7 +45,7 @@ abstract class DirectoryManagingInterceptor extends AbstractMethodInterceptor {
         final testDirName = "${ specInstance.class.name }/${testName}"
         File testDir = new File(baseDir, testDirName).canonicalFile
 
-        if (testDir.directory) {
+        if (testDir.isDirectory() ) {
             // Creating new directory next to existing one
             for (int counter = 1; testDir.directory; counter++) {
                 testDir = new File(baseDir, testDirName + "_$counter").canonicalFile
@@ -58,26 +58,11 @@ abstract class DirectoryManagingInterceptor extends AbstractMethodInterceptor {
 
     protected void destroyDirectory(invocation) {
         final specInstance = getSpec(invocation)
-        def directory = specInstance."$fieldName"
+        File directory = specInstance."$fieldName"
 
         if (clean) {
-            delete(directory)
+            assert (directory.deleteDir() && !directory.isDirectory())
         }
-    }
-
-    protected File delete(File directory) {
-        for (f in directory.listFiles()) {
-            if (f.file) {
-                assert f.delete()
-            } else if (f.directory) {
-                delete(f)
-            } else {
-                throw new RuntimeException("Unknown File instance [$f]")
-            }
-        }
-
-        assert ((!directory.listFiles()) && (directory.delete()) && (!directory.directory))
-        directory
     }
 
     abstract void install(SpecInfo spec)

--- a/src/main/groovy/com/energizedwork/spock/extensions/TempDirectoryExtension.groovy
+++ b/src/main/groovy/com/energizedwork/spock/extensions/TempDirectoryExtension.groovy
@@ -1,97 +1,137 @@
 package com.energizedwork.spock.extensions
 
 import groovy.transform.InheritConstructors
-import org.spockframework.runtime.extension.*
-import org.spockframework.runtime.model.*
+import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+import org.spockframework.runtime.extension.AbstractMethodInterceptor
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.FieldInfo
+import org.spockframework.runtime.model.SpecInfo
+import spock.lang.Specification
 
 class TempDirectoryExtension extends AbstractAnnotationDrivenExtension<TempDirectory> {
 
-	private static final File tempDir = new File(System.properties."java.io.tmpdir")
-
-	@Override
-	void visitFieldAnnotation(TempDirectory annotation, FieldInfo field) {
-		def tempDirectory = new File(tempDir, generateFilename(field.name))
-
-		def interceptor
-		if (field.isShared()) {
-			interceptor = new SharedTempDirectoryInterceptor(field, tempDirectory)
-		} else {
-			interceptor = new TempDirectoryInterceptor(field, tempDirectory)
-		}
-		interceptor.install(field.parent.getTopSpec())
-	}
-
-	private String generateFilename(String baseName) {
-		"$baseName-${Long.toHexString(System.currentTimeMillis())}"
-	}
-
+    @Override
+    void visitFieldAnnotation(TempDirectory annotation, FieldInfo field) {
+        def interceptor
+        if (field.isShared()) {
+            interceptor = new SharedTempDirectoryInterceptor(annotation.baseDir(), annotation.clean(), field.name)
+        } else {
+            interceptor = new TempDirectoryInterceptor(annotation.baseDir(), annotation.clean(), field.name)
+        }
+        interceptor.install(field.parent.getTopSpec())
+    }
 }
 
 abstract class DirectoryManagingInterceptor extends AbstractMethodInterceptor {
 
-	private final FieldInfo field
-	private final File directory
+    protected final String baseDir
+    protected final boolean clean
+    protected final String fieldName
 
-	DirectoryManagingInterceptor(FieldInfo field, File directory) {
-		this.field = field
-		this.directory = directory
-	}
+    DirectoryManagingInterceptor(String baseDir, boolean clean, String fieldName) {
+        this.baseDir = baseDir
+        this.clean = clean
+        this.fieldName = fieldName
+    }
 
-	protected void setupDirectory(target) {
-		directory.mkdirs()
-		target[field.name] = directory
-	}
+    protected final Specification getSpec( IMethodInvocation invocation )
+    {
+        invocation.instance?:invocation.sharedInstance
+    }
 
-	protected void destroyDirectory() {
-		directory.deleteDir()
-	}
+    protected void setupDirectory(IMethodInvocation invocation) {
+        final specInstance = getSpec(invocation)
+        final testName = invocation.feature?invocation.feature.name.replaceAll(/\W+/, '-'):fieldName
+        final testDirName = "${ specInstance.class.name }/${testName}"
+        File testDir = new File(baseDir, testDirName).canonicalFile
 
-	abstract void install(SpecInfo spec)
+        if (testDir.directory) {
+            // Creating new directory next to existing one
+            for (int counter = 1; testDir.directory; counter++) {
+                testDir = new File(baseDir, testDirName + "_$counter").canonicalFile
+            }
+        }
+        assert testDir.with { (!directory) && mkdirs() }, "Failed to create test directory [$testDir]"
+        specInstance."$fieldName" = testDir
+        assert specInstance."$fieldName" == testDir
+    }
+
+    protected void destroyDirectory(invocation) {
+        final specInstance = getSpec(invocation)
+        def directory = specInstance."$fieldName"
+
+        if (clean) {
+            delete(directory)
+        }
+    }
+
+    protected File delete(File directory) {
+        for (f in directory.listFiles()) {
+            if (f.file) {
+                assert f.delete()
+            } else if (f.directory) {
+                delete(f)
+            } else {
+                throw new RuntimeException("Unknown File instance [$f]")
+            }
+        }
+
+        assert ((!directory.listFiles()) && (directory.delete()) && (!directory.directory))
+        directory
+    }
+
+    abstract void install(SpecInfo spec)
 
 }
 
 @InheritConstructors
 class TempDirectoryInterceptor extends DirectoryManagingInterceptor {
 
-	@Override
-	void interceptSetupMethod(IMethodInvocation invocation) {
-		setupDirectory(invocation.target)
-		invocation.proceed()
-	}
+    @Override
+    void interceptSetupMethod(IMethodInvocation invocation) {
+        setupDirectory(invocation)
+        invocation.proceed()
+    }
 
-	@Override
-	void interceptCleanupMethod(IMethodInvocation invocation) {
-		destroyDirectory()
-		invocation.proceed()
-	}
+    @Override
+    void interceptCleanupMethod(IMethodInvocation invocation) {
+        try {
+            invocation.proceed()
+        } finally {
+            destroyDirectory(invocation)
+        }
+    }
 
-	@Override
-	void install(SpecInfo spec) {
-		spec.setupMethod.addInterceptor this
-		spec.cleanupMethod.addInterceptor this
-	}
+    @Override
+    void install(SpecInfo spec) {
+        spec.setupMethod.addInterceptor this
+        spec.cleanupMethod.addInterceptor this
+    }
 
 }
 
 @InheritConstructors
 class SharedTempDirectoryInterceptor extends DirectoryManagingInterceptor {
 
-	@Override
-	void interceptSetupSpecMethod(IMethodInvocation invocation) {
-		setupDirectory(invocation.target)
-		invocation.proceed()
-	}
+    @Override
+    void interceptSetupSpecMethod(IMethodInvocation invocation) {
+        setupDirectory(invocation)
+        invocation.proceed()
+    }
 
-	@Override
-	void interceptCleanupSpecMethod(IMethodInvocation invocation) {
-		destroyDirectory()
-		invocation.proceed()
-	}
+    @Override
+    void interceptCleanupSpecMethod(IMethodInvocation invocation) {
+        try {
+            invocation.proceed()
+        } finally {
+            destroyDirectory(invocation)
+        }
+    }
 
-	@Override
-	void install(SpecInfo spec) {
-		spec.setupSpecMethod.addInterceptor this
-		spec.cleanupSpecMethod.addInterceptor this
-	}
+    @Override
+    void install(SpecInfo spec) {
+        spec.setupSpecMethod.addInterceptor this
+        spec.cleanupSpecMethod.addInterceptor this
+    }
 
 }

--- a/src/test/groovy/com/energizedwork/spock/extensions/TempDirectorySpec.groovy
+++ b/src/test/groovy/com/energizedwork/spock/extensions/TempDirectorySpec.groovy
@@ -4,55 +4,60 @@ import spock.lang.*
 
 class TempDirectorySpec extends Specification {
 
-	@TempDirectory File tempDir
-	@Shared @TempDirectory File sharedTempDir
+    @TempDirectory File tempDir
+    @Shared @TempDirectory File sharedTempDir
+    @Shared File pointerToTempDir
 
-	def cleanup() {
-		assert !tempDir.exists(), "tempDir should have been deleted before cleanup"
-	}
+    def cleanup() {
+        // We can't check the tempDir got deleted after cleanup in the cleanup method.
+        pointerToTempDir = tempDir
+    }
 
-	def cleanupSpec() {
-		assert !sharedTempDir.exists(), "sharedTempDir should have been deleted before cleanupSpec"
-	}
+    def cleanupSpec() {
+        assert !pointerToTempDir.exists(), "tempDir should have been deleted before cleanup"
 
-	def "temp directories are created before feature method"() {
-		expect:
-		tempDir != null
-		tempDir?.isDirectory()
+        // We can't test this from our test, we'd have to use an ExternalSpec Runner to run a different spec
+        //assert !sharedTempDir.exists(), "sharedTempDir should have been deleted before cleanupSpec"
+    }
 
-		and:
-		sharedTempDir != null
-		sharedTempDir?.isDirectory()
-	}
+    def "temp directories are created before feature method"() {
+        expect:
+        tempDir != null
+        tempDir?.isDirectory()
 
-	def "files can be added to temp directories"() {
-		expect:
-		new File(tempDir, "foo").createNewFile()
+        and:
+        sharedTempDir != null
+        sharedTempDir?.isDirectory()
+    }
 
-		and:
-		new File(sharedTempDir, "bar").createNewFile()
-	}
+    def "files can be added to temp directories"() {
+        expect:
+        new File(tempDir, "foo").createNewFile()
 
-	def "per feature temp directory is cleaned after each feature method"() {
-		expect:
-		tempDir.list() == [] as String[]
-	}
+        and:
+        new File(sharedTempDir, "bar").createNewFile()
+    }
 
-	@Unroll
-	def "per feature temp directory is cleaned after each iteration of a data-driven feature"() {
-		when:
-		new File(tempDir, filename).createNewFile()
+    def "per feature temp directory is cleaned after each feature method"() {
+        expect:
+        tempDir.list() == [] as String[]
+    }
 
-		then:
-		tempDir.list() == [filename]
+    @Unroll
+    def "per feature temp directory is cleaned after each iteration of a data-driven feature"() {
+        when:
+        new File(tempDir, filename).createNewFile()
 
-		where:
-		filename << ["foo", "bar", "baz"]
-	}
+        then:
+        tempDir.list() == [filename]
 
-	def "per spec temp directory is not cleaned after each feature method"() {
-		expect:
-		sharedTempDir.list() == ["bar"]
-	}
+        where:
+        filename << ["foo", "bar", "baz"]
+    }
+
+    def "per spec temp directory is not cleaned after each feature method"() {
+        expect:
+        sharedTempDir.list() == ["bar"]
+    }
 
 }


### PR DESCRIPTION
The current spock-extensions fork from Evgeny Goldin, while good, has a few too many dependencies. I only wanted the @TempDirectory, and your repo is clearly the originator of this idea. I back ported some of this changes which specifically call the directory the name of the test and put it in the build/test directory by default. This works much better for us, since we don't want to clutter up the /tmp directory. I know that these are pretty opinionated, so feel free to just ignore this pull request, I'm just throwing it out there.

I also moved the deleting of the folder till after cleanup, since in essence we're wrapping the test, so just like we go before setup, we should go after cleanup. I talked to @pniederw and he agreed. He also hinted that this will be built into Spock directly someday.
